### PR TITLE
fix: about page layout and text in issue #21

### DIFF
--- a/lib/Layouts/AboutLayout.dart
+++ b/lib/Layouts/AboutLayout.dart
@@ -1,51 +1,11 @@
 import 'package:cadi_ai/utils/config.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:cadi_ai/Utils/strings.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
 class AboutLayout extends StatefulWidget {
   const AboutLayout({super.key});
-
-  // Order of key-value-pairs in the map below is important.
-  static const Map<String, String> aboutTextNamesAndUrls = {
-    "KaraAgro AI": "https://www.karaagro.com/",
-    "FAIR Forward - Artificial Intelligence for All":
-        'https://toolkit-digitalisierung.de/en/fair-forward/'
-  };
-
-  createTextWidget(text) {
-    return Padding(
-      padding: const EdgeInsets.only(left: 20, right: 20),
-      child: Text(
-        text,
-        textAlign: TextAlign.center,
-        style: const TextStyle(color: Colors.white60),
-      ),
-    );
-  }
-
-  createHyperLink(text, url) {
-    return InkWell(
-        child: Text(
-          text,
-          style: const TextStyle(color: Colors.lightBlue),
-        ),
-        onTap: () => launchUrlString(url));
-  }
-
-  List<Widget> constructAboutTextList() {
-    String remainderTextAfterSplit = ABOUT_APP;
-    List<Widget> aboutWidgets = [];
-
-    for (String key in aboutTextNamesAndUrls.keys) {
-      List<String> splitText = remainderTextAfterSplit.split(key);
-      aboutWidgets.add(createTextWidget(splitText[0]));
-      aboutWidgets.add(createHyperLink(key, aboutTextNamesAndUrls[key]!));
-      remainderTextAfterSplit = splitText[1];
-    }
-    aboutWidgets.add(createTextWidget(remainderTextAfterSplit));
-    return aboutWidgets;
-  }
 
   @override
   State<AboutLayout> createState() => _AboutLayoutState();
@@ -55,43 +15,50 @@ class _AboutLayoutState extends State<AboutLayout> {
   // Order of key-value-pairs in the map below is important.
   static const Map<String, String> aboutTextNamesAndUrls = {
     "KaraAgro AI": "https://www.karaagro.com/",
+    "Market-Oriented Value Chains for Jobs & Growth in the ECOWAS Region (MOVE/Comcashew)":
+        "https://www.giz.de/en/worldwide/108524.html",
     "FAIR Forward - Artificial Intelligence for All":
         'https://toolkit-digitalisierung.de/en/fair-forward/',
     "KaraAgro’s GitHub.": "https://github.com/karaagro/ai4cashew-open-source"
   };
 
   createTextWidget(text) {
-    return Padding(
-      padding: const EdgeInsets.only(left: 20, right: 20),
-      child: Text(
-        text,
-        textAlign: TextAlign.center,
-        style: const TextStyle(color: Colors.white60),
-      ),
+    return TextSpan(
+      text: text,
+      style: const TextStyle(color: Colors.white60),
     );
   }
 
-  createHyperLink(text, url) {
-    return InkWell(
-        child: Text(
-          text,
-          style: const TextStyle(color: Colors.lightBlue),
-        ),
-        onTap: () => launchUrlString(url));
+  createHyperLink(String text, String url) {
+    return TextSpan(
+        text: text,
+        style: const TextStyle(color: Colors.blue),
+        recognizer: TapGestureRecognizer()
+          ..onTap = () {
+            launchUrlString(url);
+          });
   }
 
-  List<Widget> constructAboutTextList() {
+  Widget constructAboutTextList() {
     String remainderTextAfterSplit = ABOUT_APP;
-    List<Widget> aboutWidgets = [];
+    List<TextSpan> aboutWidgets = [];
 
     for (String key in aboutTextNamesAndUrls.keys) {
       List<String> splitText = remainderTextAfterSplit.split(key);
-      aboutWidgets.add(createTextWidget(splitText[0]));
-      aboutWidgets.add(createHyperLink(key, aboutTextNamesAndUrls[key]!));
+      aboutWidgets.addAll([
+        createTextWidget(splitText[0]),
+        createHyperLink(key, aboutTextNamesAndUrls[key]!)
+      ]);
       remainderTextAfterSplit = splitText[1];
     }
     aboutWidgets.add(createTextWidget(remainderTextAfterSplit));
-    return aboutWidgets;
+
+    return Padding(
+        padding: const EdgeInsets.only(left: 20, right: 20),
+        child: RichText(
+          text: TextSpan(children: aboutWidgets),
+          textAlign: TextAlign.justify,
+        ));
   }
 
   @override
@@ -112,24 +79,32 @@ class _AboutLayoutState extends State<AboutLayout> {
                 body: Padding(
                     padding: const EdgeInsets.all(10),
                     child: Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      crossAxisAlignment: CrossAxisAlignment.center,
                       children: [
                         const SizedBox(
                             width: 300,
-                            child: Image(
-                                alignment: Alignment.topCenter,
-                                image: AssetImage('assets/cashew.png'))),
+                            height: 300,
+                            child: Padding(
+                                padding: EdgeInsets.only(
+                                    left: 20, right: 50, bottom: 10),
+                                child: Image(
+                                    alignment: Alignment.topCenter,
+                                    image: AssetImage('assets/cashew.png')))),
                         Expanded(
                             child: ListView(children: [
                           Column(children: [
-                            Padding(
-                                padding: const EdgeInsets.all(20),
-                                child: Text(
-                                  "CADI AI V$version",
-                                  style: const TextStyle(
-                                      fontSize: 20, color: Colors.white70),
-                                  textAlign: TextAlign.center,
-                                )),
-                            ...constructAboutTextList()
+                            Row(children: [
+                              Padding(
+                                  padding: const EdgeInsets.all(20),
+                                  child: Text(
+                                    "CADI AI V$version",
+                                    style: const TextStyle(
+                                        fontSize: 20, color: Colors.white70),
+                                    textAlign: TextAlign.left,
+                                  ))
+                            ]),
+                            constructAboutTextList()
                           ])
                         ]))
                       ],

--- a/lib/Utils/strings.dart
+++ b/lib/Utils/strings.dart
@@ -1,10 +1,13 @@
 // ignore: constant_identifier_names
 const ABOUT_APP = """
-CADI AI is a demo-application that uses the technology Artificial Intelligence (AI). It looks at the pictures of cashew trees and then informs the user whether the Cashew tree suffers from:
- pest infection, 
- disease or 
- abiotic stress. 
+AI-based Cashew Disease Identification (CADI AI) is a demo-application that uses the technology Artificial Intelligence (AI). It looks at drone images of cashew trees and then informs the user whether Cashew trees suffer from:
+
+- pest infection, i.e. damage to crops by insects or pests
+- disease, i.e. attacks on crops by microorganisms
+- abiotic stress caused by non-living factors (e.g. environmental factors like weather or soil conditions or the lack of mineral nutrients to the crop).
+ 
 KaraAgro AI developed CADI AI for the initiatives “Market-Oriented Value Chains for Jobs & Growth in the ECOWAS Region (MOVE/Comcashew)” and FAIR Forward - Artificial Intelligence for All 
+
 Both initiatives are implemented by the Deutsche Gesellschaft für Internationale Zusammenarbeit (GIZ) on behalf of the German Federal Ministry for Economic Cooperation and Development (BMZ). 
     
 CADI AI shall support farmers as an early warning system to quickly identify problems in their cashew farms and to keep their crops healthier and more yielding.
@@ -13,13 +16,9 @@ Please note that the application will not tell you which particular disease or p
 As with any application that uses AI: 
 Please treat the results with caution because this system can produce wrong results. It is recommended to verify the diagnoses, for example, by seeking advice from a trained agronomist or extension officer before acting upon the diagnoses of the application. 
 
-If you have any problem with the application or feedback, please reach out to support@karaagro.com. Your feedback would be very helpful to further improve the application.
+If you have any problem with the application or just have feedback, please reach out to support@karaagro.com. Your feedback would be very helpful to further improve the application.
 
-If you want to know more about how CADI was developed, please have a look at KaraAgro’s GitHub.
-
-
-
-
+If you want to know more about how CADI AI was developed, please have a look at KaraAgro’s GitHub.
 """;
 
 // ignore: constant_identifier_names
@@ -27,7 +26,7 @@ const CONFIDENCE_VALUES_EXPLAINER = """
 The numbers displayed below represent how confident the AI system
 is that the image has a certain crop stress (Abiotic, Diseased or Pest).
 
-An output of 0.68 for a crop stress means that the system is 68% confident that the crop stress is present.
+An output of 0.68 for a crop stress means that the system is 68% confident that the crop stress is present. Please note that the app can be wrong and keep this in mind when making decisions based on the systems outputs.
 """;
 
 // ignore: constant_identifier_names

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.0.0+1
+version: 1.0.0+2
 
 environment:
   sdk: ">=2.17.5 <3.0.0"


### PR DESCRIPTION
Fixes below issues 
- Left-align the text
- At the beginning, write CADI AI out in the intro text
- Reduce the Cashew nut to a smaller size. Have it only appear at the upper left side (without taking much space)
- For MOVE, please include this link behind “Market-Oriented Value Chains for Jobs & Growth in the ECOWAS Region” (MOVE/ ComCashew)
- Also edit the first paragraph where it says “It looks at the pictures of cashew trees” to “It looks as drone images of cashew trees”
- Finally the identification categories: ‘abiotic, pest and diseased’ should be briefly explained in the app